### PR TITLE
fixes user rotations

### DIFF
--- a/Reporting/UserRotationTable.cpp
+++ b/Reporting/UserRotationTable.cpp
@@ -92,34 +92,52 @@ rptRcTable* CUserRotationTable::Build(IBroker* pBroker,const CGirderKey& girderK
    GroupIndexType startGroupIdx = (girderKey.groupIndex == ALL_GROUPS ? 0 : girderKey.groupIndex);
    GroupIndexType endGroupIdx   = (girderKey.groupIndex == ALL_GROUPS ? nGroups-1 : startGroupIdx);
 
-   PierIndexType startPierIdx = pBridge->GetGirderGroupStartPier(startGroupIdx);
-
    pgsTypes::BridgeAnalysisType maxBAT = pProdForces->GetBridgeAnalysisType(analysisType,pgsTypes::Maximize);
    pgsTypes::BridgeAnalysisType minBAT = pProdForces->GetBridgeAnalysisType(analysisType,pgsTypes::Minimize);
 
-   // get poi at start and end of each segment in the girder
+   // get poi where pier rotations occur
    PoiList vPoi;
-   for ( GroupIndexType grpIdx = startGroupIdx; grpIdx <= endGroupIdx; grpIdx++ )
+   std::vector<CGirderKey> vGirderKeys;
+   pBridge->GetGirderline(girderKey.girderIndex, startGroupIdx, endGroupIdx, &vGirderKeys);
+   for (const auto& thisGirderKey : vGirderKeys)
    {
-      GirderIndexType gdrIdx = min( girderKey.girderIndex, pBridge->GetGirderCount(grpIdx)-1 );
-
-      // don't report giders that don't exist on bridge
-      SegmentIndexType nSegments = pBridge->GetSegmentCount(CGirderKey(grpIdx,gdrIdx));
-      for ( SegmentIndexType segIdx = 0; segIdx < nSegments; segIdx++ )
-      {
-         CSegmentKey segmentKey(grpIdx,gdrIdx,segIdx);
-         PoiList vSegPoi;
-         pPOI->GetPointsOfInterest(segmentKey, POI_0L | POI_10L | POI_ERECTED_SEGMENT, &vSegPoi);
-         ATLASSERT(vSegPoi.size() == 2);
-         vPoi.insert(vPoi.end(), vSegPoi.begin(), vSegPoi.end());
-      }
+       PierIndexType startPierIdx = pBridge->GetGirderGroupStartPier(thisGirderKey.groupIndex);
+       PierIndexType endPierIdx = pBridge->GetGirderGroupEndPier(thisGirderKey.groupIndex);
+       for (PierIndexType pierIdx = startPierIdx; pierIdx <= endPierIdx; pierIdx++)
+       {
+           if (pierIdx == startPierIdx)
+           {
+               CSegmentKey segmentKey(thisGirderKey, 0);
+               PoiList segPoi;
+               pPOI->GetPointsOfInterest(segmentKey, POI_0L | POI_ERECTED_SEGMENT, &segPoi);
+               vPoi.push_back(segPoi.front());
+           }
+           else if (pierIdx == endPierIdx)
+           {
+               SegmentIndexType nSegments = pBridge->GetSegmentCount(thisGirderKey);
+               CSegmentKey segmentKey(thisGirderKey, nSegments - 1);
+               PoiList segPoi;
+               pPOI->GetPointsOfInterest(segmentKey, POI_10L | POI_ERECTED_SEGMENT, &segPoi);
+               vPoi.push_back(segPoi.front());
+           }
+           else
+           {
+               Float64 Xgp;
+               VERIFY(pBridge->GetPierLocation(thisGirderKey, pierIdx, &Xgp));
+               pgsPointOfInterest poi = pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey, Xgp);
+               vPoi.push_back(poi);
+           }
+       }
    }
 
-   // TRICKY: use adapter class to get correct reaction interfaces
-   std::unique_ptr<IProductReactionAdapter> pForcesAdapt(std::make_unique<BearingDesignProductReactionAdapter>(pBearingDesign, compositeDeckIntervalIdx, girderKey) );
+   IntervalIndexType lastCompositeDeckIntervalIdx = pIntervals->GetLastCompositeDeckInterval();
+   std::unique_ptr<IProductReactionAdapter> pForces(std::make_unique<BearingDesignProductReactionAdapter>(pBearingDesign, lastCompositeDeckIntervalIdx, girderKey));
 
-   // User iterator to walk locations
-   ReactionLocationIter iter = pForcesAdapt->GetReactionLocations(pBridge);
+   // Fill up the table
+
+   ReactionLocationIter iter = pForces->GetReactionLocations(pBridge);
+   iter.First();
+   PierIndexType startPierIdx = (iter.IsDone() ? INVALID_INDEX : iter.CurrentItem().PierIdx);
 
    RowIndexType row = p_table->GetNumberOfHeaderRows();
    for (iter.First(); !iter.IsDone(); iter.Next())


### PR DESCRIPTION
I replaced the snippet of code in UserRotationTable.cpp with the snippet of code from ProductRotationTable.cpp which gathers the poi for rotations at the piers.

The user rotation table is used in the bearing design parameters report, MVR report, and Bridge Analysis Report. I used US101_Steamboat.spl for testing. The correct rotation is now displayed in the bearing design parameters report. Interestingly, no change was observed in the other 2 reports. They each report 0.0 for user DC rotations. Also, the graph of use DC rotations no longer has continuity at the splice. Same for moments. I did not do anything that affect moments, so I am guessing this change must have been made by others recently in the upstream develop branch. My other develop branches show continuity (see original bug report).

Please review and approve this change. 

<img width="1253" alt="Capture" src="https://github.com/user-attachments/assets/20746654-60d9-469a-8c54-d1fa20eb1672">

