### PR TITLE
fixes pier poi list

### DIFF
--- a/Reporting/ProductRotationTable.cpp
+++ b/Reporting/ProductRotationTable.cpp
@@ -107,33 +107,7 @@ rptRcTable* CProductRotationTable::Build(IBroker* pBroker,const CGirderKey& gird
    pBridge->GetGirderline(girderKey.girderIndex, startGroup, endGroup, &vGirderKeys);
    for (const auto& thisGirderKey : vGirderKeys)
    {
-      PierIndexType startPierIdx = pBridge->GetGirderGroupStartPier(thisGirderKey.groupIndex);
-      PierIndexType endPierIdx   = pBridge->GetGirderGroupEndPier(thisGirderKey.groupIndex);
-      for ( PierIndexType pierIdx = startPierIdx; pierIdx <= endPierIdx; pierIdx++ )
-      {
-         if ( pierIdx == startPierIdx )
-         {
-            CSegmentKey segmentKey(thisGirderKey,0);
-            PoiList segPoi;
-            pPOI->GetPointsOfInterest(segmentKey, POI_0L | POI_ERECTED_SEGMENT, &segPoi);
-            vPoi.push_back(segPoi.front());
-         }
-         else if ( pierIdx == endPierIdx )
-         {
-            SegmentIndexType nSegments = pBridge->GetSegmentCount(thisGirderKey);
-            CSegmentKey segmentKey(thisGirderKey,nSegments-1);
-            PoiList segPoi;
-            pPOI->GetPointsOfInterest(segmentKey, POI_10L | POI_ERECTED_SEGMENT, &segPoi);
-            vPoi.push_back(segPoi.front());
-         }
-         else
-         {
-            Float64 Xgp;
-            VERIFY(pBridge->GetPierLocation(thisGirderKey,pierIdx,&Xgp));
-            pgsPointOfInterest poi = pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey,Xgp);
-            vPoi.push_back(poi);
-         }
-      }
+       pPOI->GetPointsOfInterest(CSpanKey(ALL_SPANS, thisGirderKey.girderIndex), POI_ABUTMENT | POI_BOUNDARY_PIER | POI_INTERMEDIATE_PIER, &vPoi);
    }
 
    GET_IFACE2(pBroker,IBearingDesign,pBearingDesign);


### PR DESCRIPTION
The poi list used for the ProductRotationsTable, which is used in the Bearing Design Parameters Report, Bridge Analysis Report, and MVR Report is incorrect as the existing poi references are the same for all intermediate piers. The fix loops through the girder groups and uses attributes to build the poi list for the pier locations.