### PR TITLE
Fixes Product Reaction Table

### DIFF
--- a/Reporting/ProductReactionTable.cpp
+++ b/Reporting/ProductReactionTable.cpp
@@ -88,7 +88,6 @@ rptRcTable* CProductReactionTable::Build(IBroker* pBroker,const CGirderKey& gird
 
    GET_IFACE2(pBroker,IIntervals,pIntervals);
    IntervalIndexType diaphragmIntervalIdx = pIntervals->GetCastIntermediateDiaphragmsInterval();
-   IntervalIndexType lastCastDeckIntervalIdx = pIntervals->GetLastCastDeckInterval(); // deck cast be cast in multiple stages, use interval after entire deck is cast
    IntervalIndexType railingSystemIntervalIdx = pIntervals->GetInstallRailingSystemInterval();
    IntervalIndexType ljIntervalIdx = pIntervals->GetCastLongitudinalJointInterval();
    IntervalIndexType shearKeyIntervalIdx = pIntervals->GetCastShearKeyInterval();
@@ -167,12 +166,12 @@ rptRcTable* CProductReactionTable::Build(IBroker* pBroker,const CGirderKey& gird
         (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(erectSegmentIntervalIdx, reactionLocation, pgsTypes::pftGirder,    analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan ) );
      }
 
-     if ( reactionDecider.DoReport(diaphragmIntervalIdx) && reactionDecider.DoReport(lastCastDeckIntervalIdx))
+     if ( reactionDecider.DoReport(diaphragmIntervalIdx) && reactionDecider.DoReport(lastIntervalIdx))
      {
         // for simple spans and expansion piers, pier diaphragm loads are applied in the diaphragm loading interval
         // for spans made continuous or integral, pier diaphragms are cast with the deck
-        // report the total diaphragm reaction by using the deck casting interval (reactions are cumulative in this function call)
-        (*p_table)(row,col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftDiaphragm, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan));
+        // report the total diaphragm reaction by using the last interval (reactions are cumulative in this function call)
+        (*p_table)(row,col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftDiaphragm, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan));
      }
      else
      {
@@ -267,13 +266,13 @@ rptRcTable* CProductReactionTable::Build(IBroker* pBroker,const CGirderKey& gird
       {
          if (analysisType == pgsTypes::Envelope && bContinuousBeforeDeckCasting)
          {
-            if (reactionDecider.DoReport(lastCastDeckIntervalIdx))
+            if (reactionDecider.DoReport(lastIntervalIdx))
             {
-               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlab, maxBAT));
-               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlab, minBAT));
+               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlab, maxBAT));
+               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlab, minBAT));
 
-               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlabPad, maxBAT));
-               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlabPad, minBAT));
+               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlabPad, maxBAT));
+               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlabPad, minBAT));
             }
             else
             {
@@ -285,10 +284,10 @@ rptRcTable* CProductReactionTable::Build(IBroker* pBroker,const CGirderKey& gird
          }
          else
          {
-            if (reactionDecider.DoReport(lastCastDeckIntervalIdx))
+            if (reactionDecider.DoReport(lastIntervalIdx))
             {
-               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlab, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan));
-               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlabPad, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan));
+               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlab, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan));
+               (*p_table)(row, col++) << reaction.SetValue(pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlabPad, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan));
             }
             else
             {
@@ -302,10 +301,10 @@ rptRcTable* CProductReactionTable::Build(IBroker* pBroker,const CGirderKey& gird
       {
          if ( analysisType == pgsTypes::Envelope && bContinuousBeforeDeckCasting )
          {
-            if ( reactionDecider.DoReport(lastCastDeckIntervalIdx) )
+            if ( reactionDecider.DoReport(lastIntervalIdx) )
             {
-               (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlabPanel, maxBAT ) );
-               (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlabPanel, minBAT ) );
+               (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlabPanel, maxBAT ) );
+               (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlabPanel, minBAT ) );
             }
             else
             {
@@ -315,9 +314,9 @@ rptRcTable* CProductReactionTable::Build(IBroker* pBroker,const CGirderKey& gird
          }
          else
          {
-            if ( reactionDecider.DoReport(lastCastDeckIntervalIdx) )
+            if ( reactionDecider.DoReport(lastIntervalIdx) )
             {
-               (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(lastCastDeckIntervalIdx, reactionLocation, pgsTypes::pftSlabPanel, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan ) );
+               (*p_table)(row,col++) << reaction.SetValue( pForces->GetReaction(lastIntervalIdx, reactionLocation, pgsTypes::pftSlabPanel, analysisType == pgsTypes::Simple ? pgsTypes::SimpleSpan : pgsTypes::ContinuousSpan ) );
             }
             else
             {


### PR DESCRIPTION
The table originally uses the last deck cast interval for the diaphragm, slab, haunch, and slab pad reactions. However, in that interval the temporary supports are supporting the girder, so the reactions are incorrectly reporting smaller values. I have changed it to the last interval to ensure that the calculation uses the correct tributary width in the calculation.

I have verified the issue and solution by doing hand calculations on Steamboat 101 girder 1B, comparing the slab reactions from temporary and final supports and comparing to the original report and new report.

Any bridge that uses temporary supports would have this issue.