### PR TITLE
fixes rotation tables (Mantis 1590)

### DIFF
--- a/Reporting/BearingRotationTable.cpp
+++ b/Reporting/BearingRotationTable.cpp
@@ -700,8 +700,7 @@ rptRcTable* CBearingRotationTable::BuildBearingRotationTable(IBroker* pBroker, c
 
 
     // get poi where pier rotations occur
-    PoiList vPoi;
-    std::vector<std::unique_ptr<pgsPointOfInterest>> vPoi2;
+    std::vector<pgsPointOfInterest> vPoi;
     std::vector<CGirderKey> vGirderKeys;
     GroupIndexType startGroup = (girderKey.groupIndex == ALL_GROUPS ? 0 : girderKey.groupIndex);
     GroupIndexType endGroup = (girderKey.groupIndex == ALL_GROUPS ? pBridge->GetGirderGroupCount() - 1 : startGroup);
@@ -732,8 +731,7 @@ rptRcTable* CBearingRotationTable::BuildBearingRotationTable(IBroker* pBroker, c
 
                 Float64 Xgp;
                 VERIFY(pBridge->GetPierLocation(thisGirderKey, pierIdx, &Xgp));
-                vPoi2.push_back(std::make_unique<pgsPointOfInterest>(pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey, Xgp)));
-                vPoi.push_back(*vPoi2.back());
+                vPoi.push_back(pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey, Xgp));
             }
         }
     }

--- a/Reporting/BearingRotationTable.cpp
+++ b/Reporting/BearingRotationTable.cpp
@@ -701,11 +701,41 @@ rptRcTable* CBearingRotationTable::BuildBearingRotationTable(IBroker* pBroker, c
 
     // get poi where pier rotations occur
     PoiList vPoi;
+    std::vector<std::unique_ptr<pgsPointOfInterest>> vPoi2;
     std::vector<CGirderKey> vGirderKeys;
-    pBridge->GetGirderline(girderKey.girderIndex, details.startGroup, details.endGroup, &vGirderKeys);
+    GroupIndexType startGroup = (girderKey.groupIndex == ALL_GROUPS ? 0 : girderKey.groupIndex);
+    GroupIndexType endGroup = (girderKey.groupIndex == ALL_GROUPS ? pBridge->GetGirderGroupCount() - 1 : startGroup);
+    pBridge->GetGirderline(girderKey.girderIndex, startGroup, endGroup, &vGirderKeys);
     for (const auto& thisGirderKey : vGirderKeys)
     {
-        pPOI->GetPointsOfInterest(CSpanKey(ALL_SPANS, thisGirderKey.girderIndex), POI_ABUTMENT | POI_BOUNDARY_PIER | POI_INTERMEDIATE_PIER, &vPoi);
+        PierIndexType startPierIdx = pBridge->GetGirderGroupStartPier(thisGirderKey.groupIndex);
+        PierIndexType endPierIdx = pBridge->GetGirderGroupEndPier(thisGirderKey.groupIndex);
+        for (PierIndexType pierIdx = startPierIdx; pierIdx <= endPierIdx; pierIdx++)
+        {
+            if (pierIdx == startPierIdx)
+            {
+                CSegmentKey segmentKey(thisGirderKey, 0);
+                PoiList segPoi;
+                pPOI->GetPointsOfInterest(segmentKey, POI_0L | POI_ERECTED_SEGMENT, &segPoi);
+                vPoi.push_back(segPoi.front());
+            }
+            else if (pierIdx == endPierIdx)
+            {
+                SegmentIndexType nSegments = pBridge->GetSegmentCount(thisGirderKey);
+                CSegmentKey segmentKey(thisGirderKey, nSegments - 1);
+                PoiList segPoi;
+                pPOI->GetPointsOfInterest(segmentKey, POI_10L | POI_ERECTED_SEGMENT, &segPoi);
+                vPoi.push_back(segPoi.front());
+            }
+            else
+            {
+
+                Float64 Xgp;
+                VERIFY(pBridge->GetPierLocation(thisGirderKey, pierIdx, &Xgp));
+                vPoi2.push_back(std::make_unique<pgsPointOfInterest>(pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey, Xgp)));
+                vPoi.push_back(*vPoi2.back());
+            }
+        }
     }
     
 

--- a/Reporting/ProductRotationTable.cpp
+++ b/Reporting/ProductRotationTable.cpp
@@ -102,8 +102,7 @@ rptRcTable* CProductRotationTable::Build(IBroker* pBroker,const CGirderKey& gird
    p_table->SetStripeRowColumnStyle(0,rptStyleManager::GetTableStripeRowCellStyle(CB_NONE | CJ_LEFT));
 
    // get poi where pier rotations occur
-   PoiList vPoi;
-   std::vector<std::unique_ptr<pgsPointOfInterest>> vPoi2;
+   std::vector<pgsPointOfInterest> vPoi;
    std::vector<CGirderKey> vGirderKeys;
    pBridge->GetGirderline(girderKey.girderIndex, startGroup, endGroup, &vGirderKeys);
    for (const auto& thisGirderKey : vGirderKeys)
@@ -132,8 +131,7 @@ rptRcTable* CProductRotationTable::Build(IBroker* pBroker,const CGirderKey& gird
 
                Float64 Xgp;
                VERIFY(pBridge->GetPierLocation(thisGirderKey, pierIdx, &Xgp));
-               vPoi2.push_back(std::make_unique<pgsPointOfInterest>(pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey, Xgp)));
-               vPoi.push_back(*vPoi2.back());
+               vPoi.push_back(pPOI->ConvertGirderPathCoordinateToPoi(thisGirderKey, Xgp));
            }
        }
    }


### PR DESCRIPTION
The solution was to store poi on the heap instead of the stack. Then previous poi refs do not get destroyed and replaced.