### PR TITLE
Section Property Report fixes

### DIFF
--- a/Include/Reporting/SectionPropertiesChapterBuilder.h
+++ b/Include/Reporting/SectionPropertiesChapterBuilder.h
@@ -58,7 +58,7 @@ private:
 
    void WriteSectionProperties(rptParagraph& para, CComPtr<IShapeProperties>& shapeProps) const;
 
-   typedef enum SteelPropType { Straight, Harped, Temporary, Rebar, DeckRebar, Tendon } SteelPropType;
+   typedef enum SteelPropType { Straight, Harped, Temporary, Rebar, DeckRebar, Tendon, Duct } SteelPropType;
 
    struct SteelProps
    {

--- a/Reporting/SectionPropertiesChapterBuilder.cpp
+++ b/Reporting/SectionPropertiesChapterBuilder.cpp
@@ -1412,12 +1412,12 @@ rptRcImage* CSectionPropertiesChapterBuilder::CreateImage(const std::vector<Poin
         _tcscpy_s(temp_path, _MAX_PATH, _T("C:\\"));
 
     // This creates a file called _T("temp_file").TMP
-    if (::GetTempFileName(temp_path, _T("gencomp_"), 0, temp_file) == 0)
+    if (::GetTempFileName(temp_path, _T("sectprop_"), 0, temp_file) == 0)
     {
         // We could not get a temp name, so just use this default
         // (Use a tmp extension so it is in the same format as the one
         //  the OS would have created for us)
-        _tcscpy_s(temp_file, _MAX_PATH, _T("gencomp.tmp"));
+        _tcscpy_s(temp_file, _MAX_PATH, _T("sectprop.tmp"));
         should_delete = false;
     }
 

--- a/Reporting/SectionPropertiesChapterBuilder.cpp
+++ b/Reporting/SectionPropertiesChapterBuilder.cpp
@@ -619,7 +619,7 @@ rptChapter* CSectionPropertiesChapterBuilder::Build(const std::shared_ptr<const 
    INIT_UV_PROTOTYPE(rptLength2UnitValue, area, pDispUnits->Area, true);
 
    // Organize Tables
-   rptRcTable* pParentLayoutTable = rptStyleManager::CreateLayoutTable(7);
+   rptRcTable* pParentLayoutTable = rptStyleManager::CreateLayoutTable(8);
    (*pParentLayoutTable)(0, 0) << Bold(_T("Girder"));
    rptRcTable* pNonCompositeLayoutTable = rptStyleManager::CreateLayoutTable(2);
    rptRcTable* pPrimaryPointsTable = rptStyleManager::CreateDefaultTable(2);
@@ -646,6 +646,7 @@ rptChapter* CSectionPropertiesChapterBuilder::Build(const std::shared_ptr<const 
    rptRcTable* pTemporaryStrandPropertiesTable = rptStyleManager::CreateDefaultTable(3);
    rptRcTable* pRebarPropertiesTable = rptStyleManager::CreateDefaultTable(3);
    rptRcTable* pTendonPropertiesTable = rptStyleManager::CreateDefaultTable(3);
+   rptRcTable* pDuctPropertiesTable = rptStyleManager::CreateDefaultTable(3);
 
 
    if (pDeckShape)
@@ -901,6 +902,33 @@ rptChapter* CSectionPropertiesChapterBuilder::Build(const std::shared_ptr<const 
                (*pTendonPropertiesTable)(row + ductIdx, 1) << length.SetValue(y);
                area.ShowUnitTag(false);
                (*pTendonPropertiesTable)(row + ductIdx, 2) << area.SetValue(as);
+           }
+
+           (*pParentLayoutTable)(0, 7) << Bold(_T("Ducts"));
+           (*pParentLayoutTable)(0, 7) << pDuctPropertiesTable;
+
+           pDuctPropertiesTable->SetColumnStyle(0, rptStyleManager::GetTableCellStyle(CJ_CENTER));
+           pDuctPropertiesTable->SetStripeRowColumnStyle(0, rptStyleManager::GetTableStripeRowCellStyle(CJ_CENTER));
+           (*pDuctPropertiesTable)(0, 0) << COLHDR(_T("X"), rptLengthUnitTag, pDispUnits->ComponentDim);
+           (*pDuctPropertiesTable)(0, 1) << COLHDR(_T("Y"), rptLengthUnitTag, pDispUnits->ComponentDim);
+           (*pDuctPropertiesTable)(0, 2) << COLHDR(_T("A"), rptAreaUnitTag, pDispUnits->Area);
+
+           row = pDuctPropertiesTable->GetNumberOfHeaderRows();
+
+           for (DuctIndexType ductIdx = 0; ductIdx < nDucts; ductIdx++)
+           {
+               CComPtr<IPoint2d> point;
+               pTendonGeom->GetGirderDuctPoint(poi, ductIdx, &point);
+               point->get_X(&x);
+               point->get_Y(&y);
+               Float64 a = pTendonGeom->GetInsideDuctArea(segmentKey, ductIdx);
+
+               vSteelProperties.emplace_back(Duct, x, y);
+
+               (*pDuctPropertiesTable)(row + ductIdx, 0) << length.SetValue(x);
+               (*pDuctPropertiesTable)(row + ductIdx, 1) << length.SetValue(y);
+               area.ShowUnitTag(false);
+               (*pDuctPropertiesTable)(row + ductIdx, 2) << area.SetValue(a);
            }
        }
    }
@@ -1320,6 +1348,18 @@ rptRcImage* CSectionPropertiesChapterBuilder::CreateImage(const std::vector<Poin
                 graph.AddPoint(steelSeries, point);
                 graph.AddPoint(steelSeries, point2);
 			}
+            else if (steelProp.Type == Duct)
+            {
+                steelSeries = graph.CreateDataSeries(_T(""), PS_DOT, 10, SEGMENT_TENDON_FILL_COLOR);
+                WBFL::Graphing::Point point(
+                    WBFL::Units::ConvertFromSysUnits(steelProp.X, pDispUnits->ComponentDim.UnitOfMeasure),
+                    WBFL::Units::ConvertFromSysUnits(steelProp.Y, pDispUnits->ComponentDim.UnitOfMeasure));
+                WBFL::Graphing::Point point2(
+                    WBFL::Units::ConvertFromSysUnits(steelProp.X + 0.01, pDispUnits->ComponentDim.UnitOfMeasure),
+                    WBFL::Units::ConvertFromSysUnits(steelProp.Y, pDispUnits->ComponentDim.UnitOfMeasure));
+                graph.AddPoint(steelSeries, point);
+                graph.AddPoint(steelSeries, point2);
+            }
 
         }
     }

--- a/Reporting/SectionPropertiesChapterBuilder.cpp
+++ b/Reporting/SectionPropertiesChapterBuilder.cpp
@@ -821,25 +821,28 @@ rptChapter* CSectionPropertiesChapterBuilder::Build(const std::shared_ptr<const 
 
        IndexType idx = 0;
 
-       Float64 dta, dty, dba, dby;
-       pRebarGeom->GetDeckReinforcing(barCutPoi, pgsTypes::drmTop, pgsTypes::drbAll, pgsTypes::drcAll, false, &dta, &dty);
-       pRebarGeom->GetDeckReinforcing(barCutPoi, pgsTypes::drmBottom, pgsTypes::drbAll, pgsTypes::drcAll, false, &dba, &dby);
+       if (0 < secondaryPoints.size())
+       {
+           Float64 dta, dty, dba, dby;
+           pRebarGeom->GetDeckReinforcing(barCutPoi, pgsTypes::drmTop, pgsTypes::drbAll, pgsTypes::drcAll, false, &dta, &dty);
+           pRebarGeom->GetDeckReinforcing(barCutPoi, pgsTypes::drmBottom, pgsTypes::drbAll, pgsTypes::drcAll, false, &dba, &dby);
 
-       (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
-       (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dty);
-       area.ShowUnitTag(false);
-       (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dta);
-       idx++;
+           (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
+           (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dty);
+           area.ShowUnitTag(false);
+           (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dta);
+           idx++;
 
-	   vSteelProperties.emplace_back(DeckRebar, 0.0, dty);
+           vSteelProperties.emplace_back(DeckRebar, 0.0, dty);
 
-       (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
-       (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dby);
-       area.ShowUnitTag(false);
-       (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dba);
-       idx++;
+           (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
+           (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dby);
+           area.ShowUnitTag(false);
+           (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dba);
+           idx++;
 
-       vSteelProperties.emplace_back(DeckRebar, 0.0, dby);
+           vSteelProperties.emplace_back(DeckRebar, 0.0, dby);
+       }
 
        CComPtr<IEnumRebarSectionItem> enumItems;
        rebar_section->get__EnumRebarSectionItem(&enumItems);

--- a/Reporting/SectionPropertiesChapterBuilder.cpp
+++ b/Reporting/SectionPropertiesChapterBuilder.cpp
@@ -827,21 +827,27 @@ rptChapter* CSectionPropertiesChapterBuilder::Build(const std::shared_ptr<const 
            pRebarGeom->GetDeckReinforcing(barCutPoi, pgsTypes::drmTop, pgsTypes::drbAll, pgsTypes::drcAll, false, &dta, &dty);
            pRebarGeom->GetDeckReinforcing(barCutPoi, pgsTypes::drmBottom, pgsTypes::drbAll, pgsTypes::drcAll, false, &dba, &dby);
 
-           (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
-           (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dty);
-           area.ShowUnitTag(false);
-           (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dta);
-           idx++;
+           if (dta > 0.0)
+           {
+               (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
+               (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dty);
+               area.ShowUnitTag(false);
+               (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dta);
+               idx++;
 
-           vSteelProperties.emplace_back(DeckRebar, 0.0, dty);
+               vSteelProperties.emplace_back(DeckRebar, 0.0, dty);
+           }
 
-           (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
-           (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dby);
-           area.ShowUnitTag(false);
-           (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dba);
-           idx++;
+           if (dba > 0.0)
+           {
+               (*pRebarPropertiesTable)(row + idx, 0) << length.SetValue(0.0);
+               (*pRebarPropertiesTable)(row + idx, 1) << length.SetValue(dby);
+               area.ShowUnitTag(false);
+               (*pRebarPropertiesTable)(row + idx, 2) << area.SetValue(dba);
+               idx++;
 
-           vSteelProperties.emplace_back(DeckRebar, 0.0, dby);
+               vSteelProperties.emplace_back(DeckRebar, 0.0, dby);
+           }
        }
 
        CComPtr<IEnumRebarSectionItem> enumItems;


### PR DESCRIPTION
Main changes:
-adds ducts table because the duct area is different than the tendon steel area
-removes deck rebar from table when there is no deck
-fixes bug (observed in Freeport3_with_strand_strain_limit.spl) where there is no bottom mat rebar but draws it at y = 0.0 and lists it in the table.

I recommend squashing this commit with the last commit for clean history.