### PR TITLE
updates bearing related labels

### DIFF
--- a/PGSuperAppPlugin/BearingDetailsDlg.cpp
+++ b/PGSuperAppPlugin/BearingDetailsDlg.cpp
@@ -165,6 +165,7 @@ void CBearingDetailsDlg::MethodBControls(int s)
 	GetDlgItem(IDC_CHECK_FIXED_X_TRANS)->ShowWindow(s);
 	GetDlgItem(IDC_CHECK_FIXED_Y_TRANS)->ShowWindow(s);
 	GetDlgItem(IDC_CHECK_EXT_BONDED_PLATES)->ShowWindow(s);
+	GetDlgItem(IDC_TRANS_GROUP)->ShowWindow(s);
 }
 
 

--- a/PGSuperAppPlugin/PGSuperAppPlugin.rc
+++ b/PGSuperAppPlugin/PGSuperAppPlugin.rc
@@ -3943,35 +3943,38 @@ STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSM
 CAPTION "Detailed Bearing Definition"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    LTEXT           "Length",IDC_STATIC,99,13,22,8
-    EDITTEXT        IDC_EDIT_BEARING_LENGTH,126,12,42,13,ES_AUTOHSCROLL
-    LTEXT           "Unit",IDC_EDIT_BEARING_LENGTH_UNIT,175,14,14,8
-    LTEXT           "Width",IDC_STATIC,102,32,19,8
-    EDITTEXT        IDC_EDIT_BEARING_WIDTH,126,30,42,12,ES_AUTOHSCROLL
-    LTEXT           "Unit",IDC_EDIT_BEARING_WIDTH_UNIT,175,32,14,8
-    LTEXT           "Intermediate Elastomer Thickness",IDC_STATIC,14,49,107,8
-    EDITTEXT        IDC_EDIT_INT_ELASTOMER_THICK,126,48,42,12,ES_AUTOHSCROLL
-    LTEXT           "Unit",IDC_EDIT_INT_ELASTOMER_THICK_UNIT,175,50,14,8
-    LTEXT           "No. Intermediate  Elastomer Layers",IDC_STATIC,9,67,116,8
-    EDITTEXT        IDC_NUMBER_INT_LAYERS,126,66,42,12,ES_AUTOHSCROLL
-    LTEXT           "Elastomer Cover Thickness",IDC_STATIC,36,85,85,8
-    EDITTEXT        IDC_EDIT_COVER_ELASTOMER_THICK,126,84,42,12,ES_AUTOHSCROLL
-    LTEXT           "Unit",IDC_EDIT_COVER_ELASTOMER_THICK_UNIT,175,86,14,8
-    LTEXT           "Steel Shim Thickness",IDC_STATIC,54,103,67,8
-    EDITTEXT        IDC_STEEL_SHIM_THICKNESS,126,102,42,12,ES_AUTOHSCROLL
-    LTEXT           "Unit",IDC_STEEL_SHIM_THICKNESS_UNIT,175,104,14,8
-    LTEXT           "Shear Deformation",IDC_STATIC,61,121,60,8
-    EDITTEXT        IDC_EDIT_SHEAR_DEFORMATION,126,120,42,12,ES_AUTOHSCROLL
-    LTEXT           "Unit",IDC_EDIT_SHEAR_DEFORMATION_UNIT,175,121,14,8
-    CONTROL         "Fixed  X Translation",IDC_CHECK_FIXED_X_TRANS,"Button",BS_AUTOCHECKBOX | BS_LEFTTEXT | WS_TABSTOP,233,12,78,10
-    CONTROL         "Fixed  Y Translation",IDC_CHECK_FIXED_Y_TRANS,"Button",BS_AUTOCHECKBOX | BS_LEFTTEXT | WS_TABSTOP,232,30,79,10
-    CONTROL         "Has Externally Bonded Plates",IDC_CHECK_EXT_BONDED_PLATES,
-                    "Button",BS_AUTOCHECKBOX | BS_LEFTTEXT | WS_TABSTOP,204,48,107,10
-    LTEXT           "Total Height: ###",IDC_STATIC_BRG_HEIGHT,207,111,93,8
-    LTEXT           "Total Estimated Weight: ###",IDC_BRG_WEIGHT,207,123,104,8
-    DEFPUSHBUTTON   "OK",IDOK,210,153,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,264,153,50,14
-    LTEXT           "NOTE: Enter the actual shear deformation or enter the keyword ""Compute"" to have the shear deformation computed based on the distance from the hinge support",IDC_STATIC,17,137,189,24
+LTEXT           "Length", IDC_STATIC, 99, 13, 22, 8
+EDITTEXT        IDC_EDIT_BEARING_LENGTH, 126, 12, 42, 13, ES_AUTOHSCROLL
+LTEXT           "Unit", IDC_EDIT_BEARING_LENGTH_UNIT, 175, 14, 14, 8
+LTEXT           "Width", IDC_STATIC, 102, 32, 19, 8
+EDITTEXT        IDC_EDIT_BEARING_WIDTH, 126, 30, 42, 12, ES_AUTOHSCROLL
+LTEXT           "Unit", IDC_EDIT_BEARING_WIDTH_UNIT, 175, 32, 14, 8
+LTEXT           "Intermediate Elastomer Thickness", IDC_STATIC, 14, 49, 107, 8
+EDITTEXT        IDC_EDIT_INT_ELASTOMER_THICK, 126, 48, 42, 12, ES_AUTOHSCROLL
+LTEXT           "Unit", IDC_EDIT_INT_ELASTOMER_THICK_UNIT, 175, 50, 14, 8
+LTEXT           "No. Intermediate  Elastomer Layers", IDC_STATIC, 9, 67, 116, 8
+EDITTEXT        IDC_NUMBER_INT_LAYERS, 126, 66, 42, 12, ES_AUTOHSCROLL
+LTEXT           "Elastomer Cover Thickness", IDC_STATIC, 36, 85, 85, 8
+EDITTEXT        IDC_EDIT_COVER_ELASTOMER_THICK, 126, 84, 42, 12, ES_AUTOHSCROLL
+LTEXT           "Unit", IDC_EDIT_COVER_ELASTOMER_THICK_UNIT, 175, 86, 14, 8
+LTEXT           "Steel Shim Thickness", IDC_STATIC, 54, 103, 67, 8
+EDITTEXT        IDC_STEEL_SHIM_THICKNESS, 126, 102, 42, 12, ES_AUTOHSCROLL
+LTEXT           "Unit", IDC_STEEL_SHIM_THICKNESS_UNIT, 175, 104, 14, 8
+LTEXT           "Shear Deformation", IDC_STATIC, 61, 121, 60, 8
+EDITTEXT        IDC_EDIT_SHEAR_DEFORMATION, 126, 120, 42, 12, ES_AUTOHSCROLL
+LTEXT           "Unit", IDC_EDIT_SHEAR_DEFORMATION_UNIT, 175, 121, 14, 8
+GROUPBOX        "Fixed Translation", IDC_TRANS_GROUP, 199, 11, 108, 56
+CONTROL         "Parallel to Longitudinal Axis of Bridge", IDC_CHECK_FIXED_X_TRANS,
+"Button", BS_AUTOCHECKBOX | BS_LEFTTEXT | BS_MULTILINE | WS_TABSTOP, 207, 22, 95, 18
+CONTROL         "Perpendicular to Longitudinal Axis of Bridge", IDC_CHECK_FIXED_Y_TRANS,
+"Button", BS_AUTOCHECKBOX | BS_LEFTTEXT | BS_MULTILINE | WS_TABSTOP, 206, 42, 96, 20
+CONTROL         "Has Externally Bonded Plates", IDC_CHECK_EXT_BONDED_PLATES,
+"Button", BS_AUTOCHECKBOX | BS_LEFTTEXT | WS_TABSTOP, 199, 72, 103, 10
+LTEXT           "Total Height: ###", IDC_STATIC_BRG_HEIGHT, 207, 111, 93, 8
+LTEXT           "Total Estimated Weight: ###", IDC_BRG_WEIGHT, 207, 123, 104, 8
+DEFPUSHBUTTON   "OK", IDOK, 210, 153, 50, 14
+PUSHBUTTON      "Cancel", IDCANCEL, 264, 153, 50, 14
+LTEXT           "NOTE: Enter the actual shear deformation or enter the keyword ""Compute"" to have the shear deformation computed based on the distance from the model hinge", IDC_STATIC, 17, 137, 189, 24
 END
 
 IDD_COPY_BEARING_PROPERTIES DIALOGEX 0, 0, 635, 300

--- a/PGSuperAppPlugin/resource.h
+++ b/PGSuperAppPlugin/resource.h
@@ -1490,6 +1490,7 @@
 #define IDC_BUTTON_EDIT_BEARING_DETAIL_1 2067
 #define IDC_SELECT_BEARINGS             2068
 #define IDC_STATIC_BRG_NOTE             2069
+#define IDC_TRANS_GROUP                 2070
 #define IDS_E_WRITE                     2500
 #define IDS_E_UNSAFESAVE                2501
 #define IDS_E_SAVERECOVER1              2502
@@ -1683,7 +1684,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        411
 #define _APS_NEXT_COMMAND_VALUE         37026
-#define _APS_NEXT_CONTROL_VALUE         2070
+#define _APS_NEXT_CONTROL_VALUE         2071
 #define _APS_NEXT_SYMED_VALUE           115
 #endif
 #endif

--- a/Reporting/BearingMultiViewReportDlg.cpp
+++ b/Reporting/BearingMultiViewReportDlg.cpp
@@ -118,7 +118,7 @@ void CBearingMultiViewReportDlg::DoDataExchange(CDataExchange* pDX)
         if (bcType == _T("Hinge"))
         {
             CString hingeBrgStr;
-            hingeBrgStr.Format(_T("%s (Hinge)"), strBrg);
+            hingeBrgStr.Format(_T("%s (Hinged)"), strBrg);
             pBrgBox->AddString(hingeBrgStr);
         }
         else
@@ -328,7 +328,7 @@ void CBearingMultiViewReportDlg::UpdateBearingComboBox()
         if (bcType == _T("Hinge"))
         {
             CString hingeBrgStr;
-            hingeBrgStr.Format(_T("%s (Hinge)"), strBrg);
+            hingeBrgStr.Format(_T("%s (Hinged)"), strBrg);
             pBrgBox->AddString(hingeBrgStr);
         }
         else

--- a/Reporting/BearingShearDeformationTable.cpp
+++ b/Reporting/BearingShearDeformationTable.cpp
@@ -253,7 +253,7 @@ rptRcTable* CBearingShearDeformationTable::BuildBearingShearDeformationTable(std
         if (bcType == _T("Hinge"))
         {
             CString hingeBrgStr;
-            hingeBrgStr.Format(_T("%s (Hinge)"), strBrg);
+            hingeBrgStr.Format(_T("%s (Model Hinge)"), strBrg);
 
             (*p_table)(row, col++) << hingeBrgStr;
         }

--- a/Reporting/SpanGirderBearingReportDlg.cpp
+++ b/Reporting/SpanGirderBearingReportDlg.cpp
@@ -189,7 +189,7 @@
          if (bcType == _T("Hinge"))
          {
              CString hingeBrgStr;
-             hingeBrgStr.Format(_T("%s (Hinge)"), strBrg);
+             hingeBrgStr.Format(_T("%s (Hinged)"), strBrg);
              pBrgBox->AddString(hingeBrgStr);
          }
          else

--- a/SharedCtrls/MultiBearingSelectGrid.cpp
+++ b/SharedCtrls/MultiBearingSelectGrid.cpp
@@ -173,7 +173,7 @@ void CMultiBearingSelectGrid::CustomInit(const GroupGirderCollection& groupGirde
         if (bcType == _T("Hinge"))
         {
             CString hingeBrgStr;
-            hingeBrgStr.Format(_T("%s (Hinge)"), lbl);
+            hingeBrgStr.Format(_T("%s (Model Hinge)"), lbl);
             lbl = hingeBrgStr;
         }
 


### PR DESCRIPTION
<img width="360" height="251" alt="image" src="https://github.com/user-attachments/assets/edd340d9-fd4c-4ad2-b45c-47cdc6b6b3d1" />

- Adds a group box to bearing details dialog for translation fixity and clearly describes the directions relative to the bridge, rather than use "X" and "Y"
- Replaces "hinge support" with "model hinge" so the user can hopefully distinguish the LBAM hinge boundary condition from the connection type defined in the UI.
