### PR TITLE
Mantis 1646 - create shape strategy inside loop

### DIFF
--- a/PGSuperAppPlugin/BridgePlanView.cpp
+++ b/PGSuperAppPlugin/BridgePlanView.cpp
@@ -2316,165 +2316,162 @@ void CBridgePlanView::BuildPierDisplayObjects()
 
 void CBridgePlanView::DrawBearings(std::shared_ptr<WBFL::EAF::Broker> pBroker, const CGirderKey& girderKey, const ReactionLocation& reactionLocation, PierIndexType startPierIdx, GirderIndexType nGirders,
     std::shared_ptr<WBFL::DManip::CompoundDrawPointStrategy>& pStrategy)
+{
+    SHEARDEFORMATIONDETAILS details;
+    GET_IFACE2(pBroker, IBearingDesignParameters, pBearingParams);
+    BEARINGPARAMETERS params;
+    pBearingParams->GetBearingParameters(girderKey, &params);
+
+    PoiList vPoi = pBearingParams->GetBearingPoiList(girderKey, &details);
+
+    const pgsPointOfInterest& poi = vPoi[reactionLocation.PierIdx - startPierIdx];
+
+    pgsTypes::PierFaceType faceType;
+    if (reactionLocation.Face == rftBack)
     {
-        SHEARDEFORMATIONDETAILS details;
-        GET_IFACE2(pBroker, IBearingDesignParameters, pBearingParams);
-        BEARINGPARAMETERS params;
-        pBearingParams->GetBearingParameters(girderKey, &params);
+        faceType = pgsTypes::PierFaceType::Back;
+    }
+    else
+    {
+        faceType = pgsTypes::PierFaceType::Ahead;
+    }
 
-        PoiList vPoi = pBearingParams->GetBearingPoiList(girderKey, &details);
+    GET_IFACE2(pBroker, IBridgeDescription, pIBridgeDesc);
+    GET_IFACE2(pBroker, IBridge, pBridge);
+    GET_IFACE2_NOCHECK(pBroker, IGirder, pGirder);
 
-        const pgsPointOfInterest& poi = vPoi[reactionLocation.PierIdx - startPierIdx];
+    const CBridgeDescription2* pBridgeDesc = pIBridgeDesc->GetBridgeDescription();
+    const auto& pBD = pIBridgeDesc->GetBearingData(
+        reactionLocation.PierIdx, faceType,
+        reactionLocation.GirderKey.girderIndex);
 
+    CComPtr<IPoint2d> point;
+    pBridge->GetPoint(poi, pgsTypes::PlanCoordinateType::pcGlobal, &point);
 
-        pgsTypes::PierFaceType faceType;
-        if (reactionLocation.Face == rftBack)
+    auto doBearing = WBFL::DManip::PointDisplayObject::Create();
+    doBearing->SetPosition(geomUtil::GetPoint(point), false, false);
+
+    auto bearingCnt = pBD->BearingCount;
+
+    // Keep a gravity-well from one of the created shape strategies (first one)
+    std::shared_ptr<WBFL::DManip::iGravityWellStrategy> gravity_well_ptr;
+
+    for (BearingIndexType brgIdx = 0; brgIdx < bearingCnt; brgIdx++)
+    {
+        auto shapeDrawStrategy = WBFL::DManip::ShapeDrawStrategy::Create();
+
+        Float64 bearing_width = pBD->Width;
+        Float64 bearing_length = pBD->Length;
+        Float64 x, y;
+        point->get_X(&x);
+        point->get_Y(&y);
+
+        CComPtr<IAngle> pSkew;
+        pBridge->GetPierSkew(reactionLocation.PierIdx, &pSkew);
+        Float64 skew;
+        pSkew->get_Value(&skew);
+
+        Float64 mid = ((int)bearingCnt - 1) / 2.0;
+        Float64 d = ((int)brgIdx - mid) * pBD->Spacing;
+
+        Float64 ux = std::sin(-skew);
+        Float64 uy = std::cos(-skew);
+
+        x += d * ux;
+        y += d * uy;
+
+        CComPtr<IDirection> direction;
+        pGirder->GetSegmentDirection(poi.GetSegmentKey(), &direction);
+
+        Float64 dir;
+        direction->get_Value(&dir);
+
+        CComQIPtr<IShape> shape;
+        CComPtr<IPolyShape> rect;
+        CComPtr<ICircle> circle;
+
+        if (pBD->Shape == BearingShape::bsRound)
         {
-            faceType = pgsTypes::PierFaceType::Back;
-
+            circle.CoCreateInstance(CLSID_Circle);
+            CComPtr<IPoint2d>  circle_pnt;
+            circle_pnt.CoCreateInstance(CLSID_Point2d);
+            circle_pnt->put_X(x);
+            circle_pnt->put_Y(y);
+            circle->putref_Center(circle_pnt);
+            circle->put_Radius(pBD->Length * 0.5);
+            shape = circle;
         }
         else
         {
-            faceType = pgsTypes::PierFaceType::Ahead;
+            rect.CoCreateInstance(CLSID_PolyShape);
+            rect->AddPoint(x - bearing_length * 0.5, y - bearing_width * 0.5);
+            rect->AddPoint(x - bearing_length * 0.5, y + bearing_width * 0.5);
+            rect->AddPoint(x + bearing_length * 0.5, y + bearing_width * 0.5);
+            rect->AddPoint(x + bearing_length * 0.5, y - bearing_width * 0.5);
+            shape = rect;
         }
 
-        GET_IFACE2(pBroker, IBridgeDescription, pIBridgeDesc);
-        GET_IFACE2(pBroker, IBridge, pBridge);
-        GET_IFACE2_NOCHECK(pBroker, IGirder, pGirder);
+        CComQIPtr<IXYPosition> position(shape);
+        position->RotateEx(point, dir);
 
-        const CBridgeDescription2* pBridgeDesc = pIBridgeDesc->GetBridgeDescription();
-        const auto& pBD = pIBridgeDesc->GetBearingData(
-            reactionLocation.PierIdx, faceType,
-            reactionLocation.GirderKey.girderIndex);
+        shapeDrawStrategy->SetShape(geomUtil::ConvertShape(shape));
+        shapeDrawStrategy->SetSolidFillColor(BEARING_FILL_COLOR);
+        shapeDrawStrategy->SetSolidLineColor(BEARING_BORDER_COLOR);
+        shapeDrawStrategy->Fill(true);
 
-        CComPtr<IPoint2d> point;
-        pBridge->GetPoint(poi, pgsTypes::PlanCoordinateType::pcGlobal, &point);
+        pStrategy->AddStrategy(shapeDrawStrategy);
 
-        auto doBearing = WBFL::DManip::PointDisplayObject::Create();
-        doBearing->SetPosition(geomUtil::GetPoint(point), false, false);
-
-        auto bearingCnt = pBD->BearingCount;
-
-        auto shapeDrawStrategy = WBFL::DManip::ShapeDrawStrategy::Create();
-
-        for (BearingIndexType brgIdx = 0; brgIdx < bearingCnt; brgIdx++)
+        if (!gravity_well_ptr)
         {
-
-
-            Float64 bearing_width = pBD->Width;
-            Float64 bearing_length = pBD->Length;
-            Float64 x, y;
-            point->get_X(&x);
-            point->get_Y(&y);
-
-            CComPtr<IAngle> pSkew;
-            pBridge->GetPierSkew(reactionLocation.PierIdx, &pSkew);
-            Float64 skew;
-            pSkew->get_Value(&skew);
-
-            Float64 mid = ((int)bearingCnt - 1) / 2.0;
-            Float64 d = ((int)brgIdx - mid) * pBD->Spacing;
-
-            Float64 ux = std::sin(-skew);
-            Float64 uy = std::cos(-skew);
-
-            x += d * ux;
-            y += d * uy;
-
-            CComPtr<IDirection> direction;
-            pGirder->GetSegmentDirection(poi.GetSegmentKey(), &direction);
-
-            Float64 dir;
-            direction->get_Value(&dir);
-
-            CComQIPtr<IShape> shape;
-            CComPtr<IPolyShape> rect;
-            CComPtr<ICircle> circle;
-
-            if (pBD->Shape == BearingShape::bsRound)
-            {
-                circle.CoCreateInstance(CLSID_Circle);
-                CComPtr<IPoint2d>  circle_pnt;
-                circle_pnt.CoCreateInstance(CLSID_Point2d);
-                circle_pnt->put_X(x);
-                circle_pnt->put_Y(y);
-                circle->putref_Center(circle_pnt);
-                circle->put_Radius(pBD->Length*0.5);
-                shape = circle;
-            }
-            else
-            {
-                rect.CoCreateInstance(CLSID_PolyShape);
-                rect->AddPoint(x - bearing_length * 0.5, y - bearing_width * 0.5);
-                rect->AddPoint(x - bearing_length * 0.5, y + bearing_width * 0.5);
-                rect->AddPoint(x + bearing_length * 0.5, y + bearing_width * 0.5);
-                rect->AddPoint(x + bearing_length * 0.5, y - bearing_width * 0.5);
-                shape = rect;
-            }
-
-
-            CComQIPtr<IXYPosition> position(shape);
-            position->RotateEx(point, dir);
-
-            shapeDrawStrategy->SetShape(geomUtil::ConvertShape(shape));
-            shapeDrawStrategy->SetSolidFillColor(BEARING_FILL_COLOR);
-            shapeDrawStrategy->SetSolidLineColor(BEARING_BORDER_COLOR);
-            shapeDrawStrategy->Fill(true);
-
-            pStrategy->AddStrategy(shapeDrawStrategy);
+            gravity_well_ptr = std::dynamic_pointer_cast<WBFL::DManip::iGravityWellStrategy>(shapeDrawStrategy);
         }
+    }
 
-        doBearing->SetDrawingStrategy(pStrategy);
-        doBearing->SetSelectionType(WBFL::DManip::SelectionType::All);
+    doBearing->SetDrawingStrategy(pStrategy);
+    doBearing->SetSelectionType(WBFL::DManip::SelectionType::All);
 
-        auto gravity_well = std::dynamic_pointer_cast<WBFL::DManip::iGravityWellStrategy>(shapeDrawStrategy);
-        doBearing->SetGravityWellStrategy(gravity_well);
+    // use the captured gravity well (if any)
+    doBearing->SetGravityWellStrategy(gravity_well_ptr);
 
-        IDType ID = m_NextBearingID++;
-        m_BearingIDs.insert(std::make_pair(reactionLocation, ID));
-        doBearing->SetID(ID);
+    IDType ID = m_NextBearingID++;
+    m_BearingIDs.insert(std::make_pair(reactionLocation, ID));
+    doBearing->SetID(ID);
 
-        BearingDisplayObjectInfo* pInfo = new BearingDisplayObjectInfo(reactionLocation, ELASTOMERIC_DISPLAY_LIST);
-        doBearing->SetItemData((void*)pInfo, true);
+    BearingDisplayObjectInfo* pInfo = new BearingDisplayObjectInfo(reactionLocation, ELASTOMERIC_DISPLAY_LIST);
+    doBearing->SetItemData((void*)pInfo, true);
 
-        auto display_list = m_pDispMgr->FindDisplayList(ELASTOMERIC_DISPLAY_LIST);
+    auto display_list = m_pDispMgr->FindDisplayList(ELASTOMERIC_DISPLAY_LIST);
 
+    const auto& bearingType = pBridgeDesc->GetBearingType();
 
-        const auto& bearingType = pBridgeDesc->GetBearingType();
+    CString strMsg;
+    if (bearingType == pgsTypes::brtBridge)
+    {
+        strMsg = _T("Double click to edit bearings for entire bridge\nRight click for more options.");
+    }
+    else if (bearingType == pgsTypes::brtPier)
+    {
+        const CPierData2* pPier = pBridgeDesc->GetPier(reactionLocation.PierIdx);
+        strMsg.Format(_T("Double click to edit %s bearings\nRight click for more options."), LABEL_PIER_EX(pPier->IsAbutment(), reactionLocation.PierIdx));
+    }
+    else if (bearingType == pgsTypes::brtGirder)
+    {
+        const CPierData2* pPier = pBridgeDesc->GetPier(reactionLocation.PierIdx);
+        strMsg.Format(_T("Double click to edit %s bearings\nRight click for more options."), LABEL_GIRDER(girderKey));
+    }
 
-        CString strMsg;
-        if (bearingType == pgsTypes::brtBridge)
-        {
-            strMsg = _T("Double click to edit bearings for entire bridge\nRight click for more options.");
-        }
-        else if (bearingType == pgsTypes::brtPier)
-        {
-            const CPierData2* pPier = pBridgeDesc->GetPier(reactionLocation.PierIdx);
-            strMsg.Format(_T("Double click to edit %s bearings\nRight click for more options."), LABEL_PIER_EX(pPier->IsAbutment(), reactionLocation.PierIdx));
-        }
-        else if (bearingType == pgsTypes::brtGirder)
-        {
-            const CPierData2* pPier = pBridgeDesc->GetPier(reactionLocation.PierIdx);
-            strMsg.Format(_T("Double click to edit %s bearings\nRight click for more options."), LABEL_GIRDER(girderKey));
-        }
+    doBearing->SetToolTipText(strMsg);
+    doBearing->SetMaxTipWidth(TOOLTIP_WIDTH);
+    doBearing->SetTipDisplayTime(TOOLTIP_DURATION);
 
-        doBearing->SetToolTipText(strMsg);
-        doBearing->SetMaxTipWidth(TOOLTIP_WIDTH);
-        doBearing->SetTipDisplayTime(TOOLTIP_DURATION);
+    display_list->AddDisplayObject(doBearing);
 
-        display_list->AddDisplayObject(doBearing);
-
-        // Register an event sink with the bearing display object so that we can handle double clicks
-        // on the segment differently then a general double click
-
-
-        PierIndexType nPiers = pBridgeDesc->GetPierCount();
-        CBridgeModelViewChildFrame* pFrame = GetFrame();
-        GroupIndexType nGroups = pBridge->GetGirderGroupCount();
-        auto events = std::make_shared<CBridgePlanViewBearingDisplayObjectEvents>(reactionLocation, nPiers, nGroups, nGirders, pFrame);
-        doBearing->RegisterEventSink(events);
-
-    };
+    PierIndexType nPiers = pBridgeDesc->GetPierCount();
+    CBridgeModelViewChildFrame* pFrame = GetFrame();
+    GroupIndexType nGroups = pBridge->GetGirderGroupCount();
+    auto events = std::make_shared<CBridgePlanViewBearingDisplayObjectEvents>(reactionLocation, nPiers, nGroups, nGirders, pFrame);
+    doBearing->RegisterEventSink(events);
+}
 
 void CBridgePlanView::BuildBearingDisplayObjects()
 {


### PR DESCRIPTION
Previously when multiple bearings were being drawn per girder, the same shape strategy was added to the compound strategy because the shape strategy was defined outside the loop. Now a unique shape strategy gets added for each bearing. 

Also, for simplicity, the gravity well for bearings is just the first bearing shape. In the future we may want to add wells for all the bearings at the end of the girder or for the bounding box around all the bearings at the end of the girder.